### PR TITLE
Correct typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ example.js:
 
 ```js
 const fs = require('fs')
-const bsplit = require('bsplit')
+const bsplit = require('bsplit2')
 
 let i = 1
 fs.createReadStream(__filename)


### PR DESCRIPTION
Copy pasting code in the README doesn't work because the dependency is actually 'bsplit2' rather than 'bsplit'.

This change means the example can be tested out using node REPL so you can kick the tyres before using this library.